### PR TITLE
fix issue sending json with unicode quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.1.1] - 2022-09-06
+
+### Changed
+
+- Provided a fix in Send-SplunkHECEvent.ps1 to address a case where Splunk was treating unicode quotation characters as U+0022.  PowerShell escapes U+0022 with ConvertTo-Json.  This fix also escapes the other unicode quotation characters to prevent an error from Splunk HEC.
+- Added a parameter to the ConvertTo-Json command to allow processing of deeper JSON objects.
+
 ## [1.1.0] - 2022-08-23
 
 ### Added

--- a/src/UofISplunkCloud/UofISplunkCloud.psd1
+++ b/src/UofISplunkCloud/UofISplunkCloud.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofISplunkCloud.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1.0'
+ModuleVersion = '1.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -31,7 +31,7 @@ Copyright = 'The University of Illinois Board of Trustees'
 Description = 'This Powershell module acts as a limited-use wrapper for the Splunk Cloud REST API, allowing you to create scripts that run system administration commands in Splunk'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '5.1'
+PowerShellVersion = '7.0'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
+++ b/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
@@ -76,7 +76,14 @@ function Send-SplunkHECEvent {
                 'sourcetype' = $Sourcetype
                 'source' = $Source
                 'event' = $EventArray[$i]
-            } | ConvertTo-Json -Compress
+            } | ConvertTo-Json -Depth 5 -Compress
+
+            # ConvertTo-Json escapes unicode U+0022 quotes automatically
+            # https://www.ietf.org/rfc/rfc8259.txt
+            # Splunk HEC seems to interpret other unicode quotes as legitimate quotes 
+            # Escape these quotes to prevent a HEC error of: text":"Invalid data format","code":6,"
+            $Body = $Body -replace "`u{201c}", "\`u{201c}" -replace "`u{201d}", "\`u{201d}" -replace "`u{201f}", "\`u{201f}"
+
             $BulkEvent += $Body
             $count++
 

--- a/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
+++ b/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
@@ -80,7 +80,7 @@ function Send-SplunkHECEvent {
 
             # ConvertTo-Json escapes unicode U+0022 quotes automatically
             # https://www.ietf.org/rfc/rfc8259.txt
-            # Splunk HEC seems to interpret other unicode quotes as legitimate quotes 
+            # Splunk HEC seems to interpret other unicode quotes as legitimate quotes
             # Escape these quotes to prevent a HEC error of: text":"Invalid data format","code":6,"
             $Body = $Body -replace "`u{201c}", "\`u{201c}" -replace "`u{201d}", "\`u{201d}" -replace "`u{201f}", "\`u{201f}"
 


### PR DESCRIPTION
## [1.1.1] - 2022-09-06

### Changed

- Provided a fix in Send-SplunkHECEvent.ps1 to address a case where Splunk was treating unicode quotation characters as U+0022.  PowerShell escapes U+0022 with ConvertTo-Json.  This fix also escapes the other unicode quotation characters to prevent an error from Splunk HEC.
- Added a parameter to the ConvertTo-Json command to allow processing of deeper JSON objects.