### PR TITLE
add SkipCertificateCheck parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.1.3] - 2023-05-01
+
+### Changed
+
+- Send-SplunkHECEvent.ps1 now has a parameter `SkipCertificateCheck` to allow for connections to dev environments with self-signed certificates on the HEC endpoint.
+
 ## [1.1.2] - 2023-03-31
 
 ### Changed

--- a/src/UofISplunkCloud/UofISplunkCloud.psd1
+++ b/src/UofISplunkCloud/UofISplunkCloud.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofISplunkCloud.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1.2'
+ModuleVersion = '1.1.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
+++ b/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
@@ -111,7 +111,7 @@ function Send-SplunkHECEvent {
                         Invoke-RestMethod @RestSplat -SkipCertificateCheck | Out-Null
                     }
                     else {
-                        Invoke-RestMethod @RestSplat | Out-Null 
+                        Invoke-RestMethod @RestSplat | Out-Null
                     }
                 }
 

--- a/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
+++ b/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
@@ -18,6 +18,8 @@ function Send-SplunkHECEvent {
         Splunk host value that will be set for the event.
     .PARAMETER RequestSize
         Number of PowerShell objects (multiple Splunk events) to include in a single HTTP Request to Splunk HEC.
+    .PARAMETER SkipCertificateCheck
+        Switch to skip the TLS certificate checking.
     .EXAMPLE
         Send-SplunkHECEvent -HecToken $Credential -HecUri 'https://splunk.example.com:8088/services/collector' -EventData $ObjectArray -Sourcetype 'vendor:product:type:technology/format' -Source 'script.ps1'
     .EXAMPLE
@@ -53,7 +55,9 @@ function Send-SplunkHECEvent {
 
         [string]$HecUri = 'https://localhost:8088/services/collector',
 
-        [int]$RequestSize = 10
+        [int]$RequestSize = 10,
+
+        [switch]$SkipCertificateCheck
     )
 
     Begin {
@@ -103,7 +107,12 @@ function Send-SplunkHECEvent {
                 # Send event(s) to Splunk HEC endpoint
                 if ($PSCmdlet.ShouldProcess($RestSplat['Body'], 'Sending')) {
                     Write-Verbose "HTTP Request contains $($count) event(s)"
-                    Invoke-RestMethod @RestSplat | Out-Null
+                    if ($SkipCertificateCheck) {
+                        Invoke-RestMethod @RestSplat -SkipCertificateCheck | Out-Null
+                    }
+                    else {
+                        Invoke-RestMethod @RestSplat | Out-Null 
+                    }
                 }
 
                 # Reset to create a new multi-event Body

--- a/src/help/Send-SplunkHECEvent.md
+++ b/src/help/Send-SplunkHECEvent.md
@@ -14,8 +14,8 @@ Sends one or more PowerShell objects to a Splunk HTTP Event Collector (HEC) endp
 
 ```
 Send-SplunkHECEvent [-EventData] <PSObject> [-HecToken] <PSCredential> [-Source] <String>
- [-Sourcetype] <String> [[-SplunkHost] <String>] [[-HecUri] <String>] [[-RequestSize] <Int32>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-Sourcetype] <String> [[-SplunkHost] <String>] [[-HecUri] <String>] [[-RequestSize] <Int32>]
+ [-SkipCertificateCheck] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -150,6 +150,21 @@ Aliases:
 Required: False
 Position: 7
 Default value: 10
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipCertificateCheck
+Switch to skip the TLS certificate checking.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
## [1.1.3] - 2023-05-01

### Changed

- Send-SplunkHECEvent.ps1 now has a parameter `SkipCertificateCheck` to allow for connections to dev environments with self-signed certificates on the HEC endpoint.
