### PR TITLE
fix discontinued runner

### DIFF
--- a/.github/workflows/publishtogallery.yml
+++ b/.github/workflows/publishtogallery.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Only updating the runner for the publishtogallery workflow from `ubuntu-18.04` to `ubuntu-latest`.