### PR TITLE
Fix/unicode quotes

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -16,7 +16,7 @@ jobs:
         os: [macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: Install-Module -Name 'Pester' -Force -SkipPublisherCheck
       shell: pwsh

--- a/.github/workflows/publishtogallery.yml
+++ b/.github/workflows/publishtogallery.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run publish script
         env:
           NuGetApiKey: ${{ secrets.NuGetApiKey }}

--- a/.github/workflows/reminders.yml
+++ b/.github/workflows/reminders.yml
@@ -1,15 +1,18 @@
 name: PRs reviews reminder
+
 on:
   schedule:
-    # Every weekday every 2 hours during working hours, send notification 
-    - cron: "0 14-23/2 * * 1-5"
+    # Every weekday at 8:30a CST / 14:30 UTC and 1:30p CST / 19:30 UTC
+    - cron: '30 14,19 * * 1-5'
+
 jobs:
   pr-reviews-reminder:
-   runs-on: ubuntu-latest
-   steps:
-   - uses: DavideViolante/pr-reviews-reminder-action@v1.3.0
-     env:
-       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-     with:
-       webhook-url: ${{ secrets.TEAMS_WEBHOOK }}
-       provider: 'msteams'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: DavideViolante/pr-reviews-reminder-action@v2.8.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        webhook-url: ${{ secrets.TEAMS_WEBHOOK }}
+        provider: 'msteams'
+        github-provider-map: ${{ vars.MAP_USERNAMES_TEAMS }}

--- a/.github/workflows/scriptanalyzer.yml
+++ b/.github/workflows/scriptanalyzer.yml
@@ -16,7 +16,7 @@ jobs:
         os: [windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: Install-Module -Name 'PSScriptAnalyzer' -Force -SkipPublisherCheck
       shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed a previous v1.1.1 fix in Send-SplunkHECEvent.ps1 to address a case where Splunk was treating unicode quotation characters as U+0022. PowerShell escapes U+0022 with ConvertTo-Json. This change removes the escapes of the unicode quote characters since this now causes an error.  Splunk must have resolved this bug and therefore the pervious fix was preventing some events from being accepted by the HEC endpoint.
 - Update GitHub actions for `checkout` and `pr-reviews-reminder-action` workflows.
+- README.md - update the end of support to November 2026 to align with PowerShell 7.4
 
 ## [1.1.4] - 2024-11-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.1.5] - 2024-05-23
+
+### Changed
+
+- Removed a previous v1.1.1 fix in Send-SplunkHECEvent.ps1 to address a case where Splunk was treating unicode quotation characters as U+0022. PowerShell escapes U+0022 with ConvertTo-Json. This change removes the escapes of the unicode quote characters since this now causes an error.  Splunk must have resolved this bug and therefore the pervious fix was preventing some events from being accepted by the HEC endpoint.
+- Update GitHub actions for `checkout` and `pr-reviews-reminder-action` workflows.
+
 ## [1.1.4] - 2024-11-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Submit a PR on GitHub
 
 # End-of-Life and End-of-Support Dates
 
-As of the last update to this README, the expected End-of-Life and End-of-Support dates of this product are November 2024.
+As of the last update to this README, the expected End-of-Life and End-of-Support dates of this product are November 2026.
 
 End-of-Life was decided upon based on these dependencies and their End-of-Life dates:
 
-- Powershell 7.2 (November 2024)
+- Powershell 7.4 (November 2026)
 
 # To Do
 

--- a/src/UofISplunkCloud/UofISplunkCloud.psd1
+++ b/src/UofISplunkCloud/UofISplunkCloud.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofISplunkCloud.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1.4'
+ModuleVersion = '1.1.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
+++ b/src/UofISplunkCloud/functions/public/Send-SplunkHECEvent.ps1
@@ -82,12 +82,6 @@ function Send-SplunkHECEvent {
                 'event' = $EventArray[$i]
             } | ConvertTo-Json -Depth 5 -Compress
 
-            # ConvertTo-Json escapes unicode U+0022 quotes automatically
-            # https://www.ietf.org/rfc/rfc8259.txt
-            # Splunk HEC seems to interpret other unicode quotes as legitimate quotes
-            # Escape these quotes to prevent a HEC error of: text":"Invalid data format","code":6,"
-            $Body = $Body -replace "`u{201c}", "\`u{201c}" -replace "`u{201d}", "\`u{201d}" -replace "`u{201f}", "\`u{201f}"
-
             $BulkEvent += $Body
             $count++
 


### PR DESCRIPTION
## [1.1.5] - 2024-05-23

### Changed

- Removed a previous v1.1.1 fix in Send-SplunkHECEvent.ps1 to address a case where Splunk was treating unicode quotation characters as U+0022. PowerShell escapes U+0022 with ConvertTo-Json. This change removes the escapes of the unicode quote characters since this now causes an error.  Splunk must have resolved this bug and therefore the pervious fix was preventing some events from being accepted by the HEC endpoint.
- Update GitHub actions for `checkout` and `pr-reviews-reminder-action` workflows.
- README.md - update the end of support to November 2026 to align with PowerShell 7.4
