### PR TITLE
Search job user context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.1.7] - 2026-05-28
+
+### Changed
+
+- Export-SplunkData & Update-SplunkLookup:
+  - Updated Splunk REST search job creation to use the shared app namespace (servicesNS/nobody/<app>) instead of the authenticated user namespace. This avoids severe latency caused by user-specific namespace resolution while preserving app-context search behavior.
+
 ## [1.1.6] - 2026-03-04
 
 ### Changed

--- a/src/UofISplunkCloud/functions/public/Export-SplunkData.ps1
+++ b/src/UofISplunkCloud/functions/public/Export-SplunkData.ps1
@@ -27,6 +27,8 @@
     Specifies the number of results to return for each Page offsetting by this amount for each Page. Maximum value is 50,000
 .PARAMETER MaxResults
     Use this parameter if the number of results you want returned is greater than 50000. Sets the number of maximum results to return. You must specify an Offset with this parameter.
+.PARAMETER UsePrivateContext
+    Uses the authenticated user's namespace instead of the shared app namespace (nobody). Required for user-private knowledge objects such as private macros, lookups, or saved searches.
 .EXAMPLE
     Export-SplunkData -CloudDeploymentName 'illinois' -Search 'index=test test_event' -Credential $Credential -ConsoleOutput -EarliestTime '-15m'
 .EXAMPLE
@@ -52,7 +54,8 @@ function Export-SplunkData {
         [String]$LatestTime,
         [ValidateRange(1,50000)]
         [int]$Offset,
-        [int]$MaxResults
+        [int]$MaxResults,
+        [switch]$UsePrivateContext
     )
 
     process {
@@ -62,7 +65,13 @@ function Export-SplunkData {
         }
         #Set the Base URI depending on whether or not an app was specified
         If($App){
-            $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/servicesNS/nobody/$($App)"
+            If($UsePrivateContext){
+                $User = $Credential.UserName
+            }
+            Else{
+                $User = 'nobody'
+            }
+            $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/servicesNS/$($User)/$($App)"
         }
         Else{
             $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/services"

--- a/src/UofISplunkCloud/functions/public/Export-SplunkData.ps1
+++ b/src/UofISplunkCloud/functions/public/Export-SplunkData.ps1
@@ -62,7 +62,7 @@ function Export-SplunkData {
         }
         #Set the Base URI depending on whether or not an app was specified
         If($App){
-            $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/servicesNS/$($Credential.UserName)/$($App)"
+            $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/servicesNS/nobody/$($App)"
         }
         Else{
             $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/services"

--- a/src/UofISplunkCloud/functions/public/Update-SplunkLookup.ps1
+++ b/src/UofISplunkCloud/functions/public/Update-SplunkLookup.ps1
@@ -13,6 +13,8 @@
     Path to the CSV that will replace the lookup at the lookup name provided ie '.\test_2022-14-03.csv'
 .PARAMETER App
     Specify the Splunk app to use if required ie 'illinois-urbana-security-techsvc-APP'
+.PARAMETER UsePrivateContext
+    Uses the authenticated user's namespace instead of the shared app namespace (nobody). Required for user-private knowledge objects such as private macros, lookups, or saved searches.
 .EXAMPLE
     Update-SplunkLookup -Credential $Credential -CloudDeploymentName 'illinois' -LookupName 'test.csv' -NewCSVPath '.\test_2022-14-03.csv' -App 'illinois-urbana-security-techsvc-APP'
 #>
@@ -27,13 +29,20 @@ function Update-SplunkLookup {
         [String]$LookupName,
         [Parameter(Mandatory=$true)]
         [String]$NewCSVPath,
-        [String]$App
+        [String]$App,
+        [switch]$UsePrivateContext
     )
 
     process {
         #Set the Base URI depending on whether or not an app was specified
         If($App){
-            $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/servicesNS/nobody/$($App)"
+            If($UsePrivateContext){
+                $User = $Credential.UserName
+            }
+            Else{
+                $User = 'nobody'
+            }
+            $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/servicesNS/$($User)/$($App)"
         }
         Else{
             $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/services"

--- a/src/UofISplunkCloud/functions/public/Update-SplunkLookup.ps1
+++ b/src/UofISplunkCloud/functions/public/Update-SplunkLookup.ps1
@@ -33,7 +33,7 @@ function Update-SplunkLookup {
     process {
         #Set the Base URI depending on whether or not an app was specified
         If($App){
-            $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/servicesNS/$($Credential.UserName)/$($App)"
+            $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/servicesNS/nobody/$($App)"
         }
         Else{
             $BaseURI = "https://$($CloudDeploymentName).splunkcloud.com:8089/services"


### PR DESCRIPTION
## [1.1.7] - 2026-05-28

### Changed

- Export-SplunkData & Update-SplunkLookup:
  - Updated Splunk REST search job creation to use the shared app namespace (servicesNS/nobody/<app>) instead of the authenticated user namespace. This avoids severe latency caused by user-specific namespace resolution while preserving app-context search behavior.